### PR TITLE
🔥 Fix tls: server unsupported protocol 304 error

### DIFF
--- a/cycletls/roundtripper.go
+++ b/cycletls/roundtripper.go
@@ -2,17 +2,19 @@ package cycletls
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
-	"crypto/sha256"
+
 	"golang.org/x/net/http2"
 	"golang.org/x/net/proxy"
-	"strconv"
 
 	utls "github.com/refraction-networking/utls"
 )
@@ -57,7 +59,7 @@ func (rt *roundTripper) getTransport(req *http.Request, addr string) error {
 	default:
 		return fmt.Errorf("invalid URL scheme: [%v]", req.URL.Scheme)
 	}
-
+	
 	_, err := rt.dialTLS(context.Background(), "tcp", addr)
 	switch err {
 	case errProtocolNegotiated:
@@ -81,7 +83,6 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		delete(rt.cachedConnections, addr)
 		return conn, nil
 	}
-
 	rawConn, err := rt.dialer.DialContext(ctx, network, addr)
 	if err != nil {
 		return nil, err
@@ -91,6 +92,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	if host, _, err = net.SplitHostPort(addr); err != nil {
 		host = addr
 	}
+	
 
 	// conn := utls.UClient(rawConn, &utls.Config{ServerName: host}, rt.clientHelloId)
 	// if err = conn.Handshake(); err != nil {
@@ -112,12 +114,6 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	if err := conn.ApplyPreset(spec); err != nil {
 		return nil, err
 	}
-
-	if err = conn.Handshake(); err != nil {
-		_ = conn.Close()
-		return nil, err
-	}
-
 
 	//////////
 	if rt.cachedTransports[addr] != nil {

--- a/single.go
+++ b/single.go
@@ -15,7 +15,13 @@ func main() {
     }()
 	client := cycletls.Init()
 
-	response := client.Do("https://ja3er.com/json", cycletls.Options{
+	// response := client.Do("https://www.newegg.com/product/api/MoreBuyingOptions?ParentItem=14-932-411&PageNum=1&PageSize=100&PageIndex=1", cycletls.Options{
+	// 	Body : "",
+	// 	Ja3: "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-156-157-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
+	// 	UserAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+	//   }, "GET");
+
+	response := client.Do("https://www.newegg.com/product/api/MoreBuyingOptions?ParentItem=14-932-411&PageNum=1&PageSize=100&PageIndex=1", cycletls.Options{
 		Body : "",
 		Ja3: "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-156-157-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
 		UserAgent: "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",


### PR DESCRIPTION
HTTP/2 error throws up protocol not supported if the handshake is not initiated with http2