### PR TITLE
Release:   🚑 Hotfix Set Request Headers 0.0.16

### DIFF
--- a/cycletls/index.go
+++ b/cycletls/index.go
@@ -169,12 +169,14 @@ func processRequest(request cycleTLSRequest) (result fullRequest) {
 	if err != nil {
 		panic(err)
 	}
-	req.Header.Set("Host", u.Host)
 
 	//append our normal headers
-	for k, v := range headermap {
-		req.Header.Set(k, v)
+	for k, v := range request.Options.Headers {
+		if k != "Content-Length" {
+			req.Header.Set(k, v)
+		}
 	}
+	req.Header.Set("Host", u.Host)
 
 	return fullRequest{req: req, client: client, options: request}
 

--- a/cycletls/tests/integration/header_order_test.go
+++ b/cycletls/tests/integration/header_order_test.go
@@ -9,9 +9,14 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"encoding/json"
 
 	cycletls "github.com/Danny-Dasilva/CycleTLS/cycletls"
 )
+
+type HttpBinHeaders struct {
+    Headers   map[string]string      
+}
 
 //TODO rewrite this so its not reliant on goquery
 
@@ -91,5 +96,77 @@ func TestCustomHeaderOrderFailure(t *testing.T) {
 
 	if unexpected_order == headername {
 		t.Fatalf("Custom Headers Failures are ordered incorrectly: %s", headername)
+	}
+}
+
+
+func TestCustomHeadersDefaultOrder(t *testing.T) {
+	client := cycletls.Init()
+	resp, err := client.Do("https://pgl.yoyo.org/http/browser-headers.php", cycletls.Options{
+		Body:        "",
+		Ja3:         "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
+		UserAgent:   "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+		Headers:     map[string]string{"test1": "value1", "test2": "value2"},
+	}, "GET")
+	if err != nil {
+		log.Print("Request Failed: " + err.Error())
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(resp.Body)))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	headername := doc.Find(".headername").Text()
+	unexpected_order := "Accept-Encoding:Test2:Test1:Connection:Host:"
+
+	if unexpected_order == headername {
+		t.Fatalf("Custom Headers Failures are ordered incorrectly: %s", headername)
+	}
+}
+
+func TestCustomHeadersCustomOrder(t *testing.T) {
+	client := cycletls.Init()
+	resp, err := client.Do("https://pgl.yoyo.org/http/browser-headers.php", cycletls.Options{
+		Body:        "",
+		Ja3:         "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
+		UserAgent:   "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+		Headers:     map[string]string{"test1": "value1", "test2": "value2"},
+		HeaderOrder: []string{"test2", "test1"},
+	}, "GET")
+	if err != nil {
+		log.Print("Request Failed: " + err.Error())
+	}
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(resp.Body)))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	headername := doc.Find(".headername").Text()
+	unexpected_order := "Accept-Encoding:Host:Test2:Test1:Connection:"
+
+	if unexpected_order == headername {
+		t.Fatalf("Custom Headers Failures are ordered incorrectly: %s", headername)
+	}
+}
+func TestCustomHeaders(t *testing.T) {
+	client := cycletls.Init()
+	resp, err := client.Do("https://httpbin.org/headers", cycletls.Options{
+		Body:        "",
+		Ja3:         "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0",
+		UserAgent:   "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0",
+		Headers:     map[string]string{"foo": "bar"},
+	}, "GET")
+	if err != nil {
+		log.Print("Request Failed: " + err.Error())
+	}
+	var result HttpBinHeaders
+	err = json.Unmarshal([]byte(resp.Body), &result)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if result.Headers["Foo"] != "bar" {
+		t.Fatalf("Headers not applied")
 	}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Release Highlights
 Fix setting request headers
 ### Bug Fixes
-- Fix request Headers not being set
+- [Fix request Headers not being set](https://github.com/Danny-Dasilva/CycleTLS/issues/60)
 ### Enhancements
 - Add request header integration test
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CycleTLS Changelog
 
+## 0.0.15 - (2-15-2022)
+### Release Highlights
+Fix setting request headers
+### Bug Fixes
+- Fix request Headers not being set
+### Enhancements
+- Add request header integration test
+
 ## 0.0.15 - (2-11-2022)
 ### Release Highlights
 Support Ordered Request Headers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CycleTLS Changelog
 
-## 0.0.15 - (2-15-2022)
+## 0.0.16 - (2-15-2022)
 ### Release Highlights
 Fix setting request headers
 ### Bug Fixes

--- a/golang/index.go
+++ b/golang/index.go
@@ -169,12 +169,14 @@ func processRequest(request cycleTLSRequest) (result fullRequest) {
 	if err != nil {
 		panic(err)
 	}
-	req.Header.Set("Host", u.Host)
 
 	//append our normal headers
-	for k, v := range headermap {
-		req.Header.Set(k, v)
+	for k, v := range request.Options.Headers {
+		if k != "Content-Length" {
+			req.Header.Set(k, v)
+		}
 	}
+	req.Header.Set("Host", u.Host)
 
 	return fullRequest{req: req, client: client, options: request}
 

--- a/tests/ordered_headers.test.ts
+++ b/tests/ordered_headers.test.ts
@@ -48,6 +48,18 @@ test('Should correctly set header order', async () => {
 
     expect(responseOrder).toStrictEqual(expectedresponseOrder)
 
+
+
+
+      //Test Setting headers
+      const headerRequest = await cycleTLS('https://httpbin.org/headers', {
+          ja3: ja3,
+          userAgent: userAgent,
+          headers: { "foo":"bar"},
+          proxy: ''
+      });
+      expect(JSON.parse(headerRequest.body).headers.Foo).toStrictEqual("bar")
+
     cycleTLS.exit()
 
 });


### PR DESCRIPTION
## 0.0.16 - (2-15-2022)
### Release Highlights
Fix setting request headers
### Bug Fixes
- [Fix request Headers not being set](https://github.com/Danny-Dasilva/CycleTLS/issues/60)
### Enhancements
- [Add request header integration test](https://github.com/Danny-Dasilva/CycleTLS/issues/60)