### PR TITLE
Fix connections leak: close connections after dispatching request

### DIFF
--- a/cycletls/index.go
+++ b/cycletls/index.go
@@ -35,14 +35,14 @@ type cycleTLSRequest struct {
 	Options   Options `json:"options"`
 }
 
-//rename to request+client+options
+// rename to request+client+options
 type fullRequest struct {
 	req     *http.Request
 	client  http.Client
 	options cycleTLSRequest
 }
 
-//Response contains Cycletls response data
+// Response contains Cycletls response data
 type Response struct {
 	RequestID string
 	Status    int
@@ -50,7 +50,7 @@ type Response struct {
 	Headers   map[string]string
 }
 
-//JSONBody converts response body to json
+// JSONBody converts response body to json
 func (re Response) JSONBody() map[string]interface{} {
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(re.Body), &data)
@@ -60,7 +60,7 @@ func (re Response) JSONBody() map[string]interface{} {
 	return data
 }
 
-//CycleTLS creates full request and response
+// CycleTLS creates full request and response
 type CycleTLS struct {
 	ReqChan  chan fullRequest
 	RespChan chan Response
@@ -168,6 +168,8 @@ func processRequest(request cycleTLSRequest) (result fullRequest) {
 }
 
 func dispatcher(res fullRequest) (response Response, err error) {
+	defer res.client.CloseIdleConnections()
+
 	resp, err := res.client.Do(res.req)
 	if err != nil {
 


### PR DESCRIPTION
Current behavior: an instance of a client is created for each request. Each client opens a connection to a server and doesn't close it
Fix: added logic to close connections after dispatching request
Additional fix: changed context in one of the dialTLS calls to fix timeout behavior if proxy server is not responding
