### PR TITLE
Adding the InsecureSkipVerify option to a request and new FinalUrl field in the response model.

### DIFF
--- a/cycletls/client.go
+++ b/cycletls/client.go
@@ -10,9 +10,10 @@ import (
 
 type browser struct {
 	// Return a greeting that embeds the name in a message.
-	JA3       string
-	UserAgent string
-	Cookies   []Cookie
+	JA3                string
+	UserAgent          string
+	Cookies            []Cookie
+	InsecureSkipVerify bool
 }
 
 var disabledRedirect = func(req *http.Request, via []*http.Request) error {

--- a/cycletls/roundtripper.go
+++ b/cycletls/roundtripper.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	http "github.com/Danny-Dasilva/fhttp"
-	http2 "github.com/Danny-Dasilva/fhttp/http2"
+	"github.com/Danny-Dasilva/fhttp/http2"
 	utls "github.com/Danny-Dasilva/utls"
 	"golang.org/x/net/proxy"
 )
@@ -23,9 +23,10 @@ type roundTripper struct {
 	JA3       string
 	UserAgent string
 
-	Cookies           []Cookie
-	cachedConnections map[string]net.Conn
-	cachedTransports  map[string]http.RoundTripper
+	InsecureSkipVerify bool
+	Cookies            []Cookie
+	cachedConnections  map[string]net.Conn
+	cachedTransports   map[string]http.RoundTripper
 
 	dialer proxy.ContextDialer
 }
@@ -105,7 +106,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		return nil, err
 	}
 
-	conn := utls.UClient(rawConn, &utls.Config{ServerName: host, InsecureSkipVerify: true}, // MinVersion:         tls.VersionTLS10,
+	conn := utls.UClient(rawConn, &utls.Config{ServerName: host, InsecureSkipVerify: rt.InsecureSkipVerify}, // MinVersion:         tls.VersionTLS10,
 		// MaxVersion:         tls.VersionTLS13,
 
 		utls.HelloCustom)
@@ -177,21 +178,23 @@ func newRoundTripper(browser browser, dialer ...proxy.ContextDialer) http.RoundT
 		return &roundTripper{
 			dialer: dialer[0],
 
-			JA3:               browser.JA3,
-			UserAgent:         browser.UserAgent,
-			Cookies:           browser.Cookies,
-			cachedTransports:  make(map[string]http.RoundTripper),
-			cachedConnections: make(map[string]net.Conn),
+			JA3:                browser.JA3,
+			UserAgent:          browser.UserAgent,
+			Cookies:            browser.Cookies,
+			cachedTransports:   make(map[string]http.RoundTripper),
+			cachedConnections:  make(map[string]net.Conn),
+			InsecureSkipVerify: browser.InsecureSkipVerify,
 		}
 	}
 
 	return &roundTripper{
 		dialer: proxy.Direct,
 
-		JA3:               browser.JA3,
-		UserAgent:         browser.UserAgent,
-		Cookies:           browser.Cookies,
-		cachedTransports:  make(map[string]http.RoundTripper),
-		cachedConnections: make(map[string]net.Conn),
+		JA3:                browser.JA3,
+		UserAgent:          browser.UserAgent,
+		Cookies:            browser.Cookies,
+		cachedTransports:   make(map[string]http.RoundTripper),
+		cachedConnections:  make(map[string]net.Conn),
+		InsecureSkipVerify: browser.InsecureSkipVerify,
 	}
 }

--- a/cycletls/tests/integration/disable_redirect_test.go
+++ b/cycletls/tests/integration/disable_redirect_test.go
@@ -4,7 +4,6 @@
 package cycletls_test
 
 import (
-	//"fmt"
 	"log"
 	"testing"
 
@@ -44,4 +43,45 @@ func TestRedirectDisabled(t *testing.T) {
 		t.Fatal("Expected {} Got {} for Status", 301, resp.Status)
 	}
 
+}
+
+func TestRedirectEnabled_NewURL(t *testing.T) {
+	url := "https://rb.gy/3hwz5h"
+	client := cycletls.Init()
+	resp, err := client.Do(url, cycletls.Options{
+		Body:      "",
+		Ja3:       "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
+		UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36",
+	}, "GET")
+	if err != nil {
+		log.Print("Request Failed: " + err.Error())
+	}
+	if resp.Status != 200 {
+		t.Fatal("Expected {} Got {} for Status", 200, resp.Status)
+	}
+
+	if resp.FinalUrl == url {
+		t.Fatal("Expected https://www.google.com Got {} for Url", url, resp.FinalUrl)
+	}
+}
+
+func TestRedirectDisabled_NewURL(t *testing.T) {
+	url := "https://rb.gy/3hwz5h"
+	client := cycletls.Init()
+	resp, err := client.Do(url, cycletls.Options{
+		Body:            "",
+		Ja3:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-27-21,29-23-24,0",
+		UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36",
+		DisableRedirect: true,
+	}, "GET")
+	if err != nil {
+		log.Print("Request Failed: " + err.Error())
+	}
+	if resp.Status != 301 {
+		t.Fatal("Expected {} Got {} for Status", 200, resp.Status)
+	}
+
+	if resp.FinalUrl != url {
+		t.Fatal("Expected {} Got {} for Url", url, resp.FinalUrl)
+	}
 }


### PR DESCRIPTION
## Purpose of Changes
This PR adds  the InsecureSkipVerify option to a request and new FinalUrl field in the response model.

**InsecureSkipVerify** in the option - allows you to dynamically set this flag, as opposed to the static setting in the current implementation.

**FinalUrl** in the response model - This field is useful when redirection is active. For instance, if we make a request to https://rb.gy/3hwz5h, we will be redirected to the resource https://www.google.com. The FinalUrl field will then contain the final resource, i.e., https://www.google.com.

## Implementation
I added the InsecureSkipVerify option. This allows users to bypass SSL certificate verification when making HTTP requests.

I also added the FinalUrl field to the Response structure. This allows users to see the final URL to which a request was redirected.

## Testing
I tested the changes by running several test requests and confirmed that FinalUrl and InsecureSkipVerify function correctly.