### PR TITLE
Add exported go function cycletls.NewTransport()

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ func main() {
 
 ```
 
+## Example using your own custom http.Client
+
+```go
+import (
+	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+	http "github.com/Danny-Dasilva/fhttp" // note this is a drop-in replacement for net/http
+)
+
+func main() {
+	ja3 := "771,52393-52392-52244-52243-49195-49199-49196-49200-49171-49172-156-157-47-53-10,65281-0-23-35-13-5-18-16-30032-11-10,29-23-24,0"
+	ua := "Chrome Version 57.0.2987.110 (64-bit) Linux"
+
+ 	 cycleClient := &http.Client{
+ 		Transport:     cycletls.NewTransport(ja3, ua),
+ 	 }
+
+	resp, err := cycleClient.Get("https://tls.peet.ws/")
+	...
+}
+```
+
 ## Creating an instance
 
 In order to create a `cycleTLS` instance, you can run the following:

--- a/cycletls/client.go
+++ b/cycletls/client.go
@@ -36,6 +36,40 @@ func clientBuilder(browser browser, dialer proxy.ContextDialer, timeout int, dis
 	return client
 }
 
+// NewTransport creates a new HTTP client transport that modifies HTTPS requests
+// to imitiate a specific JA3 hash and User-Agent.
+// # Example Usage
+// import (
+//
+//	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+//	http "github.com/Danny-Dasilva/fhttp" // note this is a drop-in replacement for net/http
+//
+// )
+//
+// ja3 := "771,52393-52392-52244-52243-49195-49199-49196-49200-49171-49172-156-157-47-53-10,65281-0-23-35-13-5-18-16-30032-11-10,29-23-24,0"
+// ua := "Chrome Version 57.0.2987.110 (64-bit) Linux"
+//
+//	cycleClient := &http.Client{
+//		Transport:     cycletls.NewTransport(ja3, ua),
+//	}
+//
+// cycleClient.Get("https://tls.peet.ws/")
+func NewTransport(ja3 string, useragent string) http.RoundTripper {
+	return newRoundTripper(browser{
+		JA3:       ja3,
+		UserAgent: useragent,
+	})
+}
+
+// NewTransport creates a new HTTP client transport that modifies HTTPS requests
+// to imitiate a specific JA3 hash and User-Agent, optionally specifying a proxy via proxy.ContextDialer.
+func NewTransportWithProxy(ja3 string, useragent string, proxy proxy.ContextDialer) http.RoundTripper {
+	return newRoundTripper(browser{
+		JA3:       ja3,
+		UserAgent: useragent,
+	}, proxy)
+}
+
 // newClient creates a new http client
 func newClient(browser browser, timeout int, disableRedirect bool, UserAgent string, proxyURL ...string) (http.Client, error) {
 	var dialer proxy.ContextDialer


### PR DESCRIPTION
This PR addresses https://github.com/Danny-Dasilva/CycleTLS/issues/151

The idea is to be able to export the http.Client Transport, so we are able to use CycleTLS in our own http.Clients.

There are two new Exported functions:
- `NewTransport()`
- `NewTransportWithProxy`


## Example Usage:
```go
import (
	"github.com/Danny-Dasilva/CycleTLS/cycletls"
	http "github.com/Danny-Dasilva/fhttp" // note this is a drop-in replacement for net/http
)

func main() {
	ja3 := "771,52393-52392-52244-52243-49195-49199-49196-49200-49171-49172-156-157-47-53-10,65281-0-23-35-13-5-18-16-30032-11-10,29-23-24,0"
	ua := "Chrome Version 57.0.2987.110 (64-bit) Linux"

 	 cycleClient := &http.Client{
 		Transport:     cycletls.NewTransport(ja3, ua),
 	 }

	resp, err := cycleClient.Get("https://tls.peet.ws/")
	...
}

```

The caveat here is having to use the drop-in replacement for `net/http`:  `github.com/Danny-Dasilva/fhttp` everywhere `net/http` is used. But in my testing, it seems to work well.