### PR TITLE
Added connection keeping feature.

### DIFF
--- a/cycletls/client2.go
+++ b/cycletls/client2.go
@@ -1,0 +1,126 @@
+package cycletls
+
+import (
+	"context"
+	http "github.com/Danny-Dasilva/fhttp"
+	"github.com/Danny-Dasilva/fhttp/http2"
+	utls "github.com/refraction-networking/utls"
+	"golang.org/x/net/proxy"
+	"net"
+	"time"
+)
+
+type HttpClientBuilder struct {
+	Browser       *Browser
+	ProxyUrl      string
+	ClientHelloId *utls.ClientHelloID
+
+	MaxIdleConnections   int
+	MaxConnectionPerHost int
+	Timeout              time.Duration
+
+	connectDialer proxy.ContextDialer
+
+	Product *http.Client
+	Err     error
+}
+
+func (b *HttpClientBuilder) SetProxyUrl(proxyUrl string) *HttpClientBuilder {
+	return b
+}
+
+func (b *HttpClientBuilder) Build() (*http.Client, error) {
+	if b.MaxConnectionPerHost <= 0 {
+		b.MaxConnectionPerHost = 1
+	}
+
+	if b.MaxIdleConnections < 0 {
+		b.MaxIdleConnections = 0
+	}
+
+	b.buildContextDialer()
+
+	tlsDialer := newRoundTripper(*b.Browser, b.connectDialer).(*roundTripper)
+	tlsDialer.ClientHelloId = b.ClientHelloId
+
+	httpTransport := &http.Transport{
+
+		MaxIdleConns:    b.MaxIdleConnections,
+		MaxConnsPerHost: b.MaxConnectionPerHost,
+
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return tlsDialer.DoDialTlsContext(ctx, network, addr)
+		},
+
+		PostProcessPersistConn: func(persistConn *http.PersistConn) (*http.PersistConn, error) {
+			uConn, ok := persistConn.GetConn().(*utls.UConn)
+			if !ok {
+				return persistConn, nil
+			}
+
+			if uConn.ConnectionState().NegotiatedProtocol != http2.NextProtoTLS {
+				return persistConn, nil
+			}
+
+			// TODO: log.DEBUG, I don't know the equivalency of go
+			ua := parseUserAgent(b.Browser.UserAgent)
+			h2Transport := &http2.Transport{
+				DialTLS: func(network, addr string, cfg *utls.Config) (net.Conn, error) {
+					return persistConn.GetConn(), nil
+				},
+				Navigator: ua.UserAgent,
+			}
+			persistConn.SetAlt(h2Transport)
+
+			return persistConn, nil
+		},
+	}
+
+	realTransport := &customizingRequestTransport{
+		Browser:  b.Browser,
+		Delegate: httpTransport,
+	}
+
+	return &http.Client{
+		Transport: realTransport,
+		Timeout:   b.Timeout,
+	}, nil
+
+}
+
+func (b *HttpClientBuilder) buildContextDialer() {
+	if b.Err != nil {
+		return
+	}
+
+	if len(b.ProxyUrl) == 0 {
+		b.connectDialer = proxy.Direct
+		return
+	}
+
+	dialer, err := newConnectDialer(b.ProxyUrl, b.Browser.UserAgent)
+	if err != nil {
+		b.Err = err
+	}
+
+	b.connectDialer = dialer
+}
+
+type customizingRequestTransport struct {
+	Browser  *Browser
+	Delegate http.RoundTripper
+}
+
+func (t *customizingRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	const UserAgentHeader = "User-Agent"
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+
+	userAgents, ok := req.Header[UserAgentHeader]
+	if !ok || len(userAgents) == 0 {
+		req.Header[UserAgentHeader] = []string{t.Browser.UserAgent}
+	}
+
+	return t.Delegate.RoundTrip(req)
+}

--- a/cycletls/tests/integration/client2_test.go
+++ b/cycletls/tests/integration/client2_test.go
@@ -1,0 +1,150 @@
+package cycletls
+
+import (
+	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+	http "github.com/Danny-Dasilva/fhttp"
+	utls "github.com/refraction-networking/utls"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+const UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36 OPR/48.0.2685.52"
+
+func TestHttpClientBuilderWithProxyVisitingGoogle(t *testing.T) {
+
+	browser := &cycletls.Browser{
+		JA3:                "",
+		UserAgent:          UserAgent,
+		InsecureSkipVerify: true,
+	}
+
+	builder := cycletls.HttpClientBuilder{
+		Browser:              browser,
+		ClientHelloId:        &utls.HelloRandomized,
+		ProxyUrl:             "http://localhost:8888", // fiddler, watch if max tunnels correct
+		MaxConnectionPerHost: 4,
+		MaxIdleConnections:   10,
+		Timeout:              time.Second * 5,
+	}
+
+	client, err := builder.Build()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+
+			for j := 0; j < 10; j++ {
+				req, _ := http.NewRequest("GET", "https://www.google.com", nil)
+				resp, err := client.Do(req)
+				if err != nil {
+					panic(err)
+				}
+
+				data, err := io.ReadAll(resp.Body)
+				if err != nil {
+					panic(err)
+				}
+				_ = resp.Body.Close()
+
+				println(resp.StatusCode)
+				println(len(data))
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+}
+
+func TestJa3(t *testing.T) {
+
+	browser := &cycletls.Browser{
+		JA3:                "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,11-65281-35-0-51-18-10-13-23-16-5-43-27-65037-45-17513-21,29-23-24,3",
+		UserAgent:          UserAgent,
+		InsecureSkipVerify: true,
+	}
+
+	builder := cycletls.HttpClientBuilder{
+		Browser:              browser,
+		MaxConnectionPerHost: 4,
+		MaxIdleConnections:   10,
+	}
+
+	client, err := builder.Build()
+	if err != nil {
+		panic(err)
+	}
+
+	// The second call would report unexpected EOF error, I think the remote server closed the connection
+	// and I don't know how to get noticed of the server closing connection, and reopen a new connection.
+
+	req, _ := http.NewRequest("GET", "https://tls.browserleaks.com/json", nil)
+	req.Header = map[string][]string{"Connection": {"keep-alive"}}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_ = resp.Body.Close()
+
+	println(resp.StatusCode)
+	println(string(data))
+
+}
+
+func TestHttpClientBuilderWithProxyVisitingTlsLeaks(t *testing.T) {
+
+	browser := &cycletls.Browser{
+		JA3:                "",
+		UserAgent:          UserAgent,
+		InsecureSkipVerify: true,
+	}
+
+	builder := cycletls.HttpClientBuilder{
+		Browser:              browser,
+		ClientHelloId:        &utls.HelloChrome_100,
+		MaxConnectionPerHost: 4,
+		MaxIdleConnections:   10,
+	}
+
+	client, err := builder.Build()
+	if err != nil {
+		panic(err)
+	}
+
+	// The second call would report unexpected EOF error, I think the remote server closed the connection
+	// and I don't know how to get noticed of the server closing connection, and reopen a new connection.
+
+	for i := 0; i < 10; i++ {
+		req, _ := http.NewRequest("GET", "https://tls.browserleaks.com/json", nil)
+		req.Header = map[string][]string{"Connection": {"keep-alive"}}
+		resp, err := client.Do(req)
+
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		_, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		_ = resp.Body.Close()
+
+		println(resp.StatusCode)
+	}
+
+}

--- a/cycletls/tests/integration/client2_test.go
+++ b/cycletls/tests/integration/client2_test.go
@@ -21,9 +21,9 @@ func TestHttpClientBuilderWithProxyVisitingGoogle(t *testing.T) {
 	}
 
 	builder := cycletls.HttpClientBuilder{
-		Browser:              browser,
-		ClientHelloId:        &utls.HelloRandomized,
-		ProxyUrl:             "http://localhost:8888", // fiddler, watch if max tunnels correct
+		Browser:       browser,
+		ClientHelloId: &utls.HelloRandomized,
+		// ProxyUrl:             "http://localhost:8888", // fiddler, watch if max tunnels reused
 		MaxConnectionPerHost: 4,
 		MaxIdleConnections:   10,
 		Timeout:              time.Second * 5,


### PR DESCRIPTION
Hi, I've almost done with implementing connection keeping feature.

I've exposed an HttpClientBuilder structure to help to build an http.Client which could keep the connection alive.

I am not sure if my code quality is ok so I put my code in a client2.go file, if you think the code ok, I may move my code from client2.go to client.go.

One of the possible bugs is that if the connection is closed by the remote server, the http.Client would not be able to notice the closed conn, and raise an unexpected EOF error, I actaully have no idea how to fix it.

I've also modified fhttp to support the connection keeping feature. I've 
1. exposed the PersistConn structure.
2. Added a PostProcessPersistConn field to http.Transport structure so that I can modify the alt field to http2.Transport, otherwise I have to modify this alt field of PersistConn in fhttp project, which would cause circular import problem.