### PR TITLE
Add quotes for execPath strings (fixes `Could not connect to the CycleTLS instance within 4000ms` for certain cases)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ process.on("SIGINT", () => cleanExit());
 process.on("SIGTERM", () => cleanExit());
 
 const handleSpawn = (debug: boolean, fileName: string, port: number, filePath?: string) => {
-  const execPath = filePath ?? path.join(__dirname, fileName);
+  const execPath = filePath ? `"${filePath}"` : `"${path.join(__dirname, fileName)}"`;
   child = spawn(execPath, {
     env: { WS_PORT: port.toString() },
     shell: true,


### PR DESCRIPTION
I had a problem with CycleTLS on Windows and OSX which was fixed by simply adding quotes to execString.

Here's the screenshot of the problem from powershell:

![image](https://github.com/Danny-Dasilva/CycleTLS/assets/16861579/7df767d3-c7ac-45e9-954c-dd4e65a87b07)

After I added quotes the problem has gone