### PR TITLE
Fix Dead Lock on Linux after "Error Processing Request (please open an issue on Github)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,9 @@ const cleanExit = async (message?: string | Error, exit?: boolean) => {
       // For Linux/Darwin OS
       await new Promise((resolve, reject) => {
         process.kill(-child.pid);
-        if (exit) process.exit();
+        exit
+          ? process.exit()
+          : resolve(undefined);
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,12 +87,9 @@ const cleanExit = async (message?: string | Error, exit?: boolean) => {
   } else {
     if (child) {
       // For Linux/Darwin OS
-      await new Promise((resolve, reject) => {
-        process.kill(-child.pid);
-        exit
-          ? process.exit()
-          : resolve(undefined);
-      });
+      process.kill(-child.pid);
+      if (exit)
+        process.exit();
     }
   }
 };


### PR DESCRIPTION
Under Linux, when an error is encountered, the library stops sending new requests until the process is restarted.
This is because the `cleanExit` promise is never resolved when the `exit` value is `false`, causing the library to dead lock.