### PR TITLE
fix: bump fhttp to include HTTP/2 POST body fix

### DIFF
--- a/cycletls/go.mod
+++ b/cycletls/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.4
 
 require (
-	github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1
+	github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131
 	github.com/andybalholm/brotli v1.2.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/quic-go/quic-go v0.53.0

--- a/cycletls/go.sum
+++ b/cycletls/go.sum
@@ -10,6 +10,8 @@ git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGy
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1 h1:/lqhaiz7xdPr6kuaW1tQ/8DdpWdxkdyd9W/6EHz4oRw=
 github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1/go.mod h1:Hvab/V/YKCDXsEpKYKHjAXH5IFOmoq9FsfxjztEqvDc=
+github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131 h1:gRgU8L1jIWP8noBJk8p1mD3JSJNVDB3HNncjKT6SAFg=
+github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131/go.mod h1:Hvab/V/YKCDXsEpKYKHjAXH5IFOmoq9FsfxjztEqvDc=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,7 +9,7 @@ replace github.com/Danny-Dasilva/CycleTLS/cycletls => ../cycletls
 require github.com/Danny-Dasilva/CycleTLS/cycletls v1.0.29
 
 require (
-	github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1 // indirect
+	github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/gaukas/clienthellod v0.4.2 // indirect
 	github.com/gaukas/godicttls v0.0.4 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -8,8 +8,8 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1 h1:/lqhaiz7xdPr6kuaW1tQ/8DdpWdxkdyd9W/6EHz4oRw=
-github.com/Danny-Dasilva/fhttp v0.0.0-20240217042913-eeeb0b347ce1/go.mod h1:Hvab/V/YKCDXsEpKYKHjAXH5IFOmoq9FsfxjztEqvDc=
+github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131 h1:gRgU8L1jIWP8noBJk8p1mD3JSJNVDB3HNncjKT6SAFg=
+github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131/go.mod h1:Hvab/V/YKCDXsEpKYKHjAXH5IFOmoq9FsfxjztEqvDc=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
@@ -161,14 +161,11 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/qtls-go1-20 v0.3.1/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
 github.com/quic-go/quic-go v0.37.4/go.mod h1:YsbH1r4mSHPJcLF4k4zruUkLBqctEMBDR6VPvcYjIsU=
-github.com/quic-go/quic-go v0.41.0 h1:aD8MmHfgqTURWNJy48IYFg2OnxwHT3JL7ahGs73lb4k=
-github.com/quic-go/quic-go v0.41.0/go.mod h1:qCkNjqczPEvgsOnxZ0eCD14lv+B2LHlFAB++CNOh9hA=
 github.com/quic-go/quic-go v0.53.0 h1:QHX46sISpG2S03dPeZBgVIZp8dGagIaiu2FiVYvpCZI=
 github.com/quic-go/quic-go v0.53.0/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/refraction-networking/uquic v0.0.6 h1:9ol1oOaOpHDeeDlBY7u228jK+T5oic35QrFimHVaCMM=

--- a/tests/http2-post-body.test.ts
+++ b/tests/http2-post-body.test.ts
@@ -1,0 +1,170 @@
+import initCycleTLS from "../dist/index.js";
+import { withCycleTLS } from "./test-utils.js";
+import * as http2 from "node:http2";
+import * as fs from "node:fs";
+import { execSync } from "node:child_process";
+
+/**
+ * Tests for HTTP/2 POST body transmission on servers with strict flow control.
+ *
+ * These tests use a local HTTPS server configured with strict HTTP/2 settings
+ * (initialWindowSize: 16384) to verify that request bodies are correctly
+ * transmitted as HTTP/2 DATA frames.
+ *
+ * Background: fhttp's AutoUpdate() was not setting InitialWindowSize for
+ * Chrome/Firefox navigators, causing connection-level flow control to start
+ * at 0. This blocked all body writes in awaitFlowControl(), so POST/PUT/PATCH
+ * DATA frames were never sent. Servers with strict flow control would
+ * RST_STREAM with CANCEL; lenient servers happened to work.
+ */
+
+jest.setTimeout(30000);
+
+// Generate self-signed cert for local HTTP/2 server
+beforeAll(() => {
+  execSync(
+    'openssl req -x509 -newkey rsa:2048 -keyout /tmp/h2-test-key.pem -out /tmp/h2-test-cert.pem -days 1 -nodes -subj "/CN=localhost" 2>/dev/null'
+  );
+});
+
+/** Start a local HTTP/2 server with strict flow control settings. */
+function startStrictH2Server(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  return new Promise((resolve) => {
+    const server = http2.createSecureServer({
+      key: fs.readFileSync("/tmp/h2-test-key.pem"),
+      cert: fs.readFileSync("/tmp/h2-test-cert.pem"),
+      settings: {
+        initialWindowSize: 16384,
+        maxFrameSize: 16384,
+      },
+    });
+
+    server.on("stream", (stream, headers) => {
+      const method = headers[":method"];
+      let body = "";
+      stream.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      // Without the fhttp fix, the client sends RST_STREAM CANCEL which destroys
+      // the stream before 'end' fires. The stream error prevents respond() from
+      // being called, so CycleTLS times out and returns status 408. The test then
+      // fails via the expect(status).toBe(200) assertion.
+      stream.on("error", () => {});
+      stream.on("end", () => {
+        if (!stream.destroyed) {
+          stream.respond({ ":status": 200, "content-type": "application/json" });
+          stream.end(JSON.stringify({ method, bodyLength: body.length, body }));
+        }
+      });
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({
+        port,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+test("Should send form-encoded POST body over HTTP/2 with strict flow control", async () => {
+  const h2 = await startStrictH2Server();
+  try {
+    await withCycleTLS({ port: 9220 }, async (cycleTLS) => {
+      const response = await cycleTLS(
+        `https://localhost:${h2.port}/test`,
+        {
+          body: "key1=value1&key2=value2",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          insecureSkipVerify: true,
+        },
+        "post"
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.method).toBe("POST");
+      expect(responseBody.body).toBe("key1=value1&key2=value2");
+    });
+  } finally {
+    await h2.close();
+  }
+});
+
+test("Should send JSON POST body over HTTP/2 with strict flow control", async () => {
+  const h2 = await startStrictH2Server();
+  try {
+    await withCycleTLS({ port: 9221 }, async (cycleTLS) => {
+      const jsonBody = JSON.stringify({ message: "hello", number: 42 });
+      const response = await cycleTLS(
+        `https://localhost:${h2.port}/test`,
+        {
+          body: jsonBody,
+          headers: { "Content-Type": "application/json" },
+          insecureSkipVerify: true,
+        },
+        "post"
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.method).toBe("POST");
+      expect(JSON.parse(responseBody.body)).toEqual({
+        message: "hello",
+        number: 42,
+      });
+    });
+  } finally {
+    await h2.close();
+  }
+});
+
+test("Should send PUT body over HTTP/2 with strict flow control", async () => {
+  const h2 = await startStrictH2Server();
+  try {
+    await withCycleTLS({ port: 9222 }, async (cycleTLS) => {
+      const response = await cycleTLS(
+        `https://localhost:${h2.port}/test`,
+        {
+          body: "updated=true",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          insecureSkipVerify: true,
+        },
+        "put"
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.method).toBe("PUT");
+      expect(responseBody.body).toBe("updated=true");
+    });
+  } finally {
+    await h2.close();
+  }
+});
+
+test("Should send PATCH body over HTTP/2 with strict flow control", async () => {
+  const h2 = await startStrictH2Server();
+  try {
+    await withCycleTLS({ port: 9223 }, async (cycleTLS) => {
+      const response = await cycleTLS(
+        `https://localhost:${h2.port}/test`,
+        {
+          body: JSON.stringify({ field: "patched" }),
+          headers: { "Content-Type": "application/json" },
+          insecureSkipVerify: true,
+        },
+        "patch"
+      );
+
+      expect(response.status).toBe(200);
+      const responseBody = await response.json();
+      expect(responseBody.method).toBe("PATCH");
+      expect(JSON.parse(responseBody.body)).toEqual({ field: "patched" });
+    });
+  } finally {
+    await h2.close();
+  }
+});


### PR DESCRIPTION
## Summary

Updates `fhttp` from `v0.0.0-20240217` to `v0.0.0-20260106` to fix HTTP/2 POST/PUT/PATCH body transmission for Chrome and Firefox navigators.

## Problem

`AutoUpdate()` in `fhttp/http2/transport.go` sets `HeaderTableSize` and `MaxHeaderListSize` for Chrome/Firefox navigators but does not set `InitialWindowSize`. This leaves it at 0, so `cc.flow.add(int32(0))` gives the connection-level flow window zero capacity. All body writes block in `awaitFlowControl()` and DATA frames are never sent.

The `default` navigator case correctly sets `InitialWindowSize = initialWindowSize`. The fix adds the same assignment to the Chrome and Firefox cases.

Servers with strict HTTP/2 flow control send `RST_STREAM CANCEL` when the body never arrives. Lenient servers happen to tolerate the missing flow control.

## Reproduction

This PR has two commits for easy verification:

**Commit 1** (`e3f5b38`) adds tests only — no fix. They fail:
```bash
git checkout e3f5b38
npm install
npx jest tests/http2-post-body.test.ts --forceExit
# Result: 4 failed (expected 200, received 408)
```

**Commit 2** (`083eb59`) bumps fhttp — tests pass:
```bash
git checkout 083eb59
cd src && go build -o ../dist/index-mac-arm64 . && cd ..
npx jest tests/http2-post-body.test.ts --forceExit
# Result: 4 passed
```

## Tests

The tests start a local HTTPS server with strict HTTP/2 settings (`initialWindowSize: 16384`) and verify form-encoded POST, JSON POST, PUT, and PATCH bodies are transmitted correctly.

## Changes

- `tests/http2-post-body.test.ts` — new test file
- `cycletls/go.mod` — bump fhttp
- `src/go.mod` — same (indirect)
- `go.sum` files updated

All existing Go tests pass with the updated dependency.