### PR TITLE
ci(goreleaser): fix broken action + split into dedicated workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,50 @@
+name: 🚀 GoReleaser
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  release:
+    types: [created, published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          # On a tag push or release event, do a real release.
+          # On a regular push to main, build snapshot artifacts (no tag, no GitHub release).
+          args: >-
+            release --clean
+            ${{ (startsWith(github.ref, 'refs/tags/') || github.event_name == 'release') && '' || '--snapshot' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload snapshot artifacts
+        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: cycletls-snapshot-${{ github.sha }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+          retention-days: 14

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,24 +67,3 @@ jobs:
         working-directory: ./
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-  goreleaser:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v3
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
-          distribution: goreleaser
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,73 @@
+version: 2
+project_name: cycletls
+
+# Note: no `before.hooks` — `go mod tidy` would walk the whole repo and fail
+# on legacy relative imports under tests/golang/. The build itself only
+# touches ./src which has a clean module.
+
+builds:
+  - id: cycletls
+    dir: ./src
+    main: ./
+    binary: cycletls
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: arm
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "0.0.0-snapshot-{{ .ShortCommit }}"
+
+git:
+  tag_sort: -version:refname
+  prerelease_suffix: "-pre"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^Merge'
+
+release:
+  draft: false
+  prerelease: auto
+  mode: append


### PR DESCRIPTION
## Summary

The `goreleaser` job in `publish.yml` has been failing on every push to `main` since the `--rm-dist` flag was renamed to `--clean` in goreleaser v1.21+. There was also no `.goreleaser.yml` config, outdated action versions, and the job was coupled to the NPM publish workflow despite needing different triggers.

## Changes

1. **New `.goreleaser.yml`** — builds `./src/` across `linux/darwin/windows/freebsd × amd64/arm/arm64` (matches the existing `package.json` cross-build matrix). Uses a static `0.0.0-snapshot-{{ .ShortCommit }}` template so the legacy non-semver tags (`cycletls/v1.0.30`, etc.) don't break the snapshot path. Skips `before: hooks: go mod tidy` because `tests/golang/` contains legacy relative imports that fail `go mod tidy`.
2. **New `.github/workflows/goreleaser.yml`** — runs on every push to main (snapshot build, uploaded as a 14-day artifact) and on tag/release events (real GitHub release with assets). Uses `goreleaser-action@v6`, `setup-go@v5` with Go 1.25, `checkout@v4`, `--clean` flag, `contents: write` permission, and `workflow_dispatch` for manual triggers.
3. **Removed the goreleaser job from `publish.yml`** — keeps NPM publish gated by `startsWith(github.event.head_commit.message, 'Release:')` while goreleaser is decoupled and unconditional.

## Verification

Locally with `goreleaser` v2:

```
$ goreleaser release --snapshot --clean
  ...
  • building paths=src binaries=cycletls target=linux_amd64_v1
  • building paths=src binaries=cycletls target=linux_arm_7
  • building paths=src binaries=cycletls target=linux_arm64_v8.0
  • building paths=src binaries=cycletls target=darwin_amd64_v1
  • building paths=src binaries=cycletls target=darwin_arm64_v8.0
  • building paths=src binaries=cycletls target=windows_amd64_v1
  • building paths=src binaries=cycletls target=freebsd_amd64_v1
  • archiving — 7 tarballs/zip
  • calculating checksums
  • release succeeded after 11s
```

## Test plan

- [x] `goreleaser check` passes locally
- [x] Snapshot build produces 7 platform binaries + `checksums.txt` locally in 11s
- [ ] CI snapshot build on push (this PR) produces the artifact
- [ ] Future tag push produces a real GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)