### PR TITLE
Support multi-value request headers

### DIFF
--- a/cycletls/header_options_test.go
+++ b/cycletls/header_options_test.go
@@ -1,0 +1,52 @@
+package cycletls
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	http "github.com/Danny-Dasilva/fhttp"
+)
+
+func TestOptionsUnmarshalJSONSupportsMultiValueHeaders(t *testing.T) {
+	var options Options
+	err := json.Unmarshal([]byte(`{
+		"url": "https://example.com",
+		"headers": {
+			"x-CUSTOM-case": ["one", "two"],
+			"accept": "text/plain"
+		}
+	}`), &options)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON returned error: %v", err)
+	}
+
+	if got, want := options.Headers["x-CUSTOM-case"], "one"; got != want {
+		t.Fatalf("Headers first value = %q, want %q", got, want)
+	}
+
+	wantValues := []string{"one", "two"}
+	if got := options.HeaderValues["x-CUSTOM-case"]; !reflect.DeepEqual(got, wantValues) {
+		t.Fatalf("HeaderValues = %#v, want %#v", got, wantValues)
+	}
+}
+
+func TestSetRequestHeadersPreservesCasingAndMultipleValues(t *testing.T) {
+	headers := make(http.Header)
+	options := Options{
+		HeaderValues: map[string][]string{
+			"x-CUSTOM-case": []string{"one", "two"},
+		},
+	}
+
+	setRequestHeaders(headers, options, false)
+
+	if _, ok := headers["X-Custom-Case"]; ok {
+		t.Fatalf("header key was canonicalized: %#v", headers)
+	}
+
+	want := []string{"one", "two"}
+	if got := headers["x-CUSTOM-case"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("headers = %#v, want %#v", got, want)
+	}
+}

--- a/cycletls/index.go
+++ b/cycletls/index.go
@@ -53,11 +53,14 @@ type Cookie struct {
 
 // Options sets CycleTLS client options
 type Options struct {
-	URL       string            `json:"url"`
-	Method    string            `json:"method"`
-	Headers   map[string]string `json:"headers"`
-	Body      string            `json:"body"`
-	BodyBytes []byte            `json:"bodyBytes"` // New field for binary request data
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	// HeaderValues supports request headers with multiple values and exact key casing.
+	// It is populated automatically when JSON headers contain array values.
+	HeaderValues map[string][]string `json:"-"`
+	Body         string              `json:"body"`
+	BodyBytes    []byte              `json:"bodyBytes"` // New field for binary request data
 
 	// TLS fingerprinting options
 	Ja3              string `json:"ja3"`
@@ -89,6 +92,52 @@ type Options struct {
 
 	// Connection reuse options
 	EnableConnectionReuse bool `json:"enableConnectionReuse"` // Enable connection reuse across requests (default: true)
+}
+
+// UnmarshalJSON accepts both legacy string header values and multi-value arrays.
+func (options *Options) UnmarshalJSON(data []byte) error {
+	type optionsAlias Options
+	var raw struct {
+		optionsAlias
+		Headers map[string]json.RawMessage `json:"headers"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*options = Options(raw.optionsAlias)
+	options.Headers = make(map[string]string, len(raw.Headers))
+	options.HeaderValues = make(map[string][]string, len(raw.Headers))
+
+	for k, rawValue := range raw.Headers {
+		var single string
+		if err := json.Unmarshal(rawValue, &single); err == nil {
+			options.Headers[k] = single
+			options.HeaderValues[k] = []string{single}
+			continue
+		}
+
+		var values []string
+		if err := json.Unmarshal(rawValue, &values); err != nil {
+			return err
+		}
+		options.HeaderValues[k] = append([]string(nil), values...)
+		if len(values) > 0 {
+			options.Headers[k] = values[0]
+		} else {
+			options.Headers[k] = ""
+		}
+	}
+
+	if len(options.Headers) == 0 {
+		options.Headers = nil
+	}
+	if len(options.HeaderValues) == 0 {
+		options.HeaderValues = nil
+	}
+
+	return nil
 }
 
 type cycleTLSRequest struct {
@@ -123,6 +172,45 @@ func WithRawBytes() Option {
 			client.RespChanV2 = make(chan []byte, 100)
 		}
 	}
+}
+
+func (options Options) requestHeaders() map[string][]string {
+	if len(options.HeaderValues) > 0 {
+		headers := make(map[string][]string, len(options.HeaderValues)+len(options.Headers))
+		for k, values := range options.HeaderValues {
+			headers[k] = append([]string(nil), values...)
+		}
+		for k, v := range options.Headers {
+			if _, ok := headers[k]; !ok {
+				headers[k] = []string{v}
+			}
+		}
+		return headers
+	}
+
+	headers := make(map[string][]string, len(options.Headers))
+	for k, v := range options.Headers {
+		headers[k] = []string{v}
+	}
+	return headers
+}
+
+func setRequestHeaders(headers http.Header, options Options, skipContentLength bool) {
+	for k, values := range options.requestHeaders() {
+		if skipContentLength && strings.EqualFold(k, "Content-Length") {
+			continue
+		}
+		headers[k] = append([]string(nil), values...)
+	}
+}
+
+func hasRequestHeader(options Options, name string) bool {
+	for k := range options.requestHeaders() {
+		if strings.EqualFold(k, name) {
+			return true
+		}
+	}
+	return false
 }
 
 var activeRequests = make(map[string]context.CancelFunc)
@@ -241,14 +329,13 @@ func processRequest(request cycleTLSRequest) (result fullRequest) {
 		)
 	}
 
-	headermap := make(map[string]string)
 	//TODO: Shorten this
 	headerorderkey := []string{}
+	requestHeaders := request.Options.requestHeaders()
 	for _, key := range headerorder {
-		for k, v := range request.Options.Headers {
+		for k := range requestHeaders {
 			lowercasekey := strings.ToLower(k)
 			if key == lowercasekey {
-				headermap[k] = v
 				headerorderkey = append(headerorderkey, lowercasekey)
 			}
 		}
@@ -272,19 +359,13 @@ func processRequest(request cycleTLSRequest) (result fullRequest) {
 	}
 
 	//append our normal headers
-	for k, v := range request.Options.Headers {
-		if k != "Content-Length" {
-			req.Header.Set(k, v)
-		}
-	}
+	setRequestHeaders(req.Header, request.Options, true)
 
 	// Respect user-provided Host header for domain fronting; otherwise default to URL host
-	if _, ok := request.Options.Headers["Host"]; !ok {
-		if _, ok := request.Options.Headers["host"]; !ok {
-			req.Header.Set("Host", u.Host)
-		}
+	if !hasRequestHeader(request.Options, "Host") {
+		req.Header["Host"] = []string{u.Host}
 	}
-	req.Header.Set("user-agent", request.Options.UserAgent)
+	req.Header["user-agent"] = []string{request.Options.UserAgent}
 
 	activeRequestsMutex.Lock()
 	activeRequests[request.RequestID] = cancel
@@ -355,11 +436,7 @@ func dispatchHTTP3Request(request cycleTLSRequest) (result fullRequest) {
 	}
 
 	// Set headers for HTTP/3 request
-	for k, v := range request.Options.Headers {
-		if k != "Content-Length" {
-			req.Header.Set(k, v)
-		}
-	}
+	setRequestHeaders(req.Header, request.Options, true)
 
 	// Parse URL for Host header
 	u, err := url.Parse(request.Options.URL)
@@ -367,12 +444,10 @@ func dispatchHTTP3Request(request cycleTLSRequest) (result fullRequest) {
 		panic(err)
 	}
 	// Respect user-provided Host header for domain fronting; otherwise default to URL host
-	if _, ok := request.Options.Headers["Host"]; !ok {
-		if _, ok := request.Options.Headers["host"]; !ok {
-			req.Header.Set("Host", u.Host)
-		}
+	if !hasRequestHeader(request.Options, "Host") {
+		req.Header["Host"] = []string{u.Host}
 	}
-	req.Header.Set("user-agent", request.Options.UserAgent)
+	req.Header["user-agent"] = []string{request.Options.UserAgent}
 
 	activeRequestsMutex.Lock()
 	activeRequests[request.RequestID] = cancel
@@ -432,9 +507,7 @@ func dispatchSSERequest(request cycleTLSRequest) (result fullRequest) {
 
 	// Prepare headers for SSE
 	headers := make(http.Header)
-	for k, v := range request.Options.Headers {
-		headers.Set(k, v)
-	}
+	setRequestHeaders(headers, request.Options, false)
 
 	// Create SSE client
 	sseClient := NewSSEClient(&client, headers)
@@ -494,9 +567,7 @@ func dispatchWebSocketRequest(request cycleTLSRequest) (result fullRequest) {
 
 	// Prepare headers for WebSocket
 	headers := make(http.Header)
-	for k, v := range request.Options.Headers {
-		headers.Set(k, v)
-	}
+	setRequestHeaders(headers, request.Options, false)
 
 	// Create WebSocket client
 	convertedHeaders := ConvertFhttpHeader(headers)
@@ -1435,9 +1506,7 @@ func (client CycleTLS) Do(URL string, options Options, Method string) (Response,
 	}
 
 	// Set headers
-	for k, v := range options.Headers {
-		req.Header.Set(k, v)
-	}
+	setRequestHeaders(req.Header, options, false)
 
 	// Make request
 	resp, err := httpClient.Do(req)

--- a/cycletls/tests/integration/header_wire_test.go
+++ b/cycletls/tests/integration/header_wire_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+// +build integration
+
+package cycletls_test
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	cycletls "github.com/Danny-Dasilva/CycleTLS/cycletls"
+)
+
+func TestHTTP1RequestHeadersPreserveCasingOnWire(t *testing.T) {
+	rawRequest := captureRawHTTP1Request(t, cycletls.Options{
+		Headers: map[string]string{
+			"x-CUSTOM-case": "one",
+		},
+		UserAgent:  "CycleTLS-Test",
+		ForceHTTP1: true,
+	})
+
+	assertHeaderLine(t, rawRequest, "x-CUSTOM-case: one")
+	assertNoHeaderLine(t, rawRequest, "X-Custom-Case:")
+}
+
+func TestHTTP1RequestHeadersSendMultipleValuesOnWire(t *testing.T) {
+	rawRequest := captureRawHTTP1Request(t, cycletls.Options{
+		HeaderValues: map[string][]string{
+			"x-MULTI-value": []string{"one", "two"},
+		},
+		UserAgent:  "CycleTLS-Test",
+		ForceHTTP1: true,
+	})
+
+	assertHeaderLine(t, rawRequest, "x-MULTI-value: one")
+	assertHeaderLine(t, rawRequest, "x-MULTI-value: two")
+	if got := countHeaderLines(rawRequest, "x-MULTI-value:"); got != 2 {
+		t.Fatalf("x-MULTI-value line count = %d, want 2\nraw request:\n%s", got, rawRequest)
+	}
+	assertNoHeaderLine(t, rawRequest, "X-Multi-Value:")
+}
+
+func captureRawHTTP1Request(t *testing.T, options cycletls.Options) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	defer listener.Close()
+
+	rawRequests := make(chan string, 1)
+	serverErrors := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErrors <- err
+			return
+		}
+		defer conn.Close()
+
+		if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			serverErrors <- err
+			return
+		}
+
+		reader := bufio.NewReader(conn)
+		var raw strings.Builder
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				serverErrors <- err
+				return
+			}
+			raw.WriteString(line)
+			if line == "\r\n" {
+				break
+			}
+		}
+
+		rawRequests <- raw.String()
+		_, err = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"))
+		if err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	client := cycletls.Init()
+	defer client.Close()
+
+	resp, err := client.Do(fmt.Sprintf("http://%s/", listener.Addr().String()), options, "GET")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("status = %d, want 200, body: %q", resp.Status, resp.Body)
+	}
+
+	select {
+	case rawRequest := <-rawRequests:
+		return rawRequest
+	case err := <-serverErrors:
+		t.Fatalf("server failed: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for raw request")
+	}
+
+	return ""
+}
+
+func assertHeaderLine(t *testing.T, rawRequest string, line string) {
+	t.Helper()
+	if !strings.Contains(rawRequest, "\r\n"+line+"\r\n") {
+		t.Fatalf("missing header line %q\nraw request:\n%s", line, rawRequest)
+	}
+}
+
+func assertNoHeaderLine(t *testing.T, rawRequest string, linePrefix string) {
+	t.Helper()
+	if countHeaderLines(rawRequest, linePrefix) != 0 {
+		t.Fatalf("unexpected header line prefix %q\nraw request:\n%s", linePrefix, rawRequest)
+	}
+}
+
+func countHeaderLines(rawRequest string, linePrefix string) int {
+	count := 0
+	for _, line := range strings.Split(rawRequest, "\r\n") {
+		if strings.HasPrefix(line, linePrefix) {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary
- accept string or string-array request header values when decoding JSON options
- preserve exact request header casing by assigning header slices directly instead of using Header.Set
- apply the same header handling to HTTP, HTTP/3, SSE, WebSocket, and CycleTLS.Do paths
- add local raw HTTP/1 wire integration tests that assert header casing and repeated values without relying on httpbin or net/http header parsing

## Tests
- go test -tags=integration ./tests/integration -run 'TestHTTP1RequestHeaders' -count=1 -v

## Related issues

#251 #278 