### PR TITLE
Evict idle connections from the roundTripper cache

### DIFF
--- a/cycletls/roundtripper.go
+++ b/cycletls/roundtripper.go
@@ -55,8 +55,28 @@ type roundTripper struct {
 	cachedConnections map[string]net.Conn
 	cachedTransports  map[string]http.RoundTripper
 
+	// Idle eviction. cachedTransports keeps a transport per address, and a
+	// transport keeps its own connections alive indefinitely -- fhttp's
+	// http2.Transport only honours an idle timeout when it was built from an
+	// http.Transport (t1), which is unexported and nil here. Without eviction a
+	// long-lived client accumulates one open socket per distinct host it has
+	// ever contacted.
+	lastUsed  map[string]time.Time
+	lastSweep time.Time
+
 	dialer proxy.ContextDialer
 }
+
+// idleConnTTL is how long a per-address transport may go unused before its idle
+// connections are closed. Transports untouched for twice that are dropped from
+// the cache entirely; the delay before eviction keeps a request that is still
+// in flight from having its entry removed out from under it.
+const idleConnTTL = 90 * time.Second
+
+// idleSweepInterval throttles how often a sweep actually walks the cache, since
+// it is driven from RoundTrip rather than a background goroutine -- a
+// roundTripper has no Close hook to stop one with.
+const idleSweepInterval = 30 * time.Second
 
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Apply cookies to the request
@@ -172,6 +192,9 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return rt.makeHTTP3Request(req, conn)
 	}
 
+	rt.markUsed(addr)
+	rt.sweepIdle()
+
 	// Use cached transport if available, otherwise create a new one
 	if _, ok := rt.cachedTransports[addr]; !ok {
 		if err := rt.getTransport(req, addr); err != nil {
@@ -228,8 +251,16 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	rt.Lock()
 	defer rt.Unlock()
 
-	// Return cached connection if available
+	// Return cached connection if available.
+	//
+	// This entry exists only to hand the just-negotiated connection to the
+	// transport's first DialTLS call, so it is consumed rather than kept.
+	// Leaving it in place meant every later dial for this address -- the ones a
+	// transport makes when it wants a second connection -- was answered with
+	// the same conn it was already using, and the map held a reference to every
+	// connection the client had ever opened.
 	if conn := rt.cachedConnections[addr]; conn != nil {
+		delete(rt.cachedConnections, addr)
 		return conn, nil
 	}
 
@@ -588,6 +619,81 @@ func (rt *roundTripper) getAddressMutex(addr string) *sync.Mutex {
 	return mu
 }
 
+// deleteAddressMutex drops the per-address creation mutex once its address is
+// gone from the cache, so addressMutexes does not outlive what it guards.
+func (rt *roundTripper) deleteAddressMutex(addr string) {
+	rt.addressMutexLock.Lock()
+	defer rt.addressMutexLock.Unlock()
+	delete(rt.addressMutexes, addr)
+}
+
+// markUsed records that addr was just requested, so the sweep can tell a live
+// address from one nothing has touched in a while.
+func (rt *roundTripper) markUsed(addr string) {
+	rt.Lock()
+	defer rt.Unlock()
+
+	if rt.lastUsed == nil {
+		rt.lastUsed = make(map[string]time.Time)
+	}
+	rt.lastUsed[addr] = time.Now()
+}
+
+// sweepIdle closes the idle connections of transports nothing has used in
+// idleConnTTL, and forgets transports idle for twice that.
+//
+// CloseIdleConnections is the operation that matters here: on both
+// http.Transport and http2.Transport it closes only connections with no request
+// on them, so a sweep cannot interrupt traffic in flight. Dropping the cache
+// entry is held back to 2*idleConnTTL because a request that is still running
+// keeps using a transport this map no longer refers to, and its connections
+// would then have nothing left to close them.
+func (rt *roundTripper) sweepIdle() {
+	rt.Lock()
+
+	now := time.Now()
+	if now.Sub(rt.lastSweep) < idleSweepInterval {
+		rt.Unlock()
+		return
+	}
+	rt.lastSweep = now
+
+	type closer interface{ CloseIdleConnections() }
+	var toClose []closer
+	var evicted []string
+
+	for addr, transport := range rt.cachedTransports {
+		idle := now.Sub(rt.lastUsed[addr])
+		if idle < idleConnTTL {
+			continue
+		}
+		if c, ok := transport.(closer); ok {
+			toClose = append(toClose, c)
+		}
+		if idle < 2*idleConnTTL {
+			continue
+		}
+		delete(rt.cachedTransports, addr)
+		delete(rt.lastUsed, addr)
+		if conn := rt.cachedConnections[addr]; conn != nil {
+			_ = conn.Close()
+			delete(rt.cachedConnections, addr)
+		}
+		evicted = append(evicted, addr)
+	}
+	rt.Unlock()
+
+	// Outside the lock: CloseIdleConnections walks the transport's own pool and
+	// has no reason to reach back into this roundTripper, but holding rt while
+	// calling into another package's locks is not worth the risk.
+	for _, c := range toClose {
+		c.CloseIdleConnections()
+	}
+	for _, addr := range evicted {
+		rt.deleteAddressMutex(addr)
+	}
+}
+
 // CloseIdleConnections closes connections that have been idle for too long
 // If selectedAddr is provided, only close connections not matching this address
 func (rt *roundTripper) CloseIdleConnections(selectedAddr ...string) {
@@ -636,6 +742,7 @@ func newRoundTripper(browser Browser, dialer ...proxy.ContextDialer) http.RoundT
 		Cookies:            browser.Cookies,
 		cachedTransports:   make(map[string]http.RoundTripper),
 		cachedConnections:  make(map[string]net.Conn),
+		lastUsed:           make(map[string]time.Time),
 		InsecureSkipVerify: browser.InsecureSkipVerify,
 		ForceHTTP1:         browser.ForceHTTP1,
 		ForceHTTP3:         browser.ForceHTTP3,

--- a/cycletls/roundtripper_idle_test.go
+++ b/cycletls/roundtripper_idle_test.go
@@ -1,0 +1,179 @@
+package cycletls
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	http "github.com/Danny-Dasilva/fhttp"
+)
+
+// fakeIdleTransport records whether CloseIdleConnections was called on it.
+type fakeIdleTransport struct {
+	mu     sync.Mutex
+	closed int
+}
+
+func (f *fakeIdleTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func (f *fakeIdleTransport) CloseIdleConnections() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed++
+}
+
+func (f *fakeIdleTransport) closes() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+
+// fakeConn is a net.Conn that only remembers whether it was closed.
+type fakeConn struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *fakeConn) Read([]byte) (int, error)         { return 0, nil }
+func (c *fakeConn) Write([]byte) (int, error)        { return 0, nil }
+func (c *fakeConn) LocalAddr() net.Addr              { return nil }
+func (c *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (c *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *fakeConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+
+func (c *fakeConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+func newTestRoundTripper() *roundTripper {
+	return &roundTripper{
+		cachedTransports:  make(map[string]http.RoundTripper),
+		cachedConnections: make(map[string]net.Conn),
+		lastUsed:          make(map[string]time.Time),
+		addressMutexes:    make(map[string]*sync.Mutex),
+	}
+}
+
+// A transport still in use must not be swept, or a sweep would be closing
+// connections out from under live traffic.
+func TestSweepIdleKeepsRecentlyUsedTransports(t *testing.T) {
+	rt := newTestRoundTripper()
+	ft := &fakeIdleTransport{}
+	rt.cachedTransports["live.example:443"] = ft
+	rt.lastUsed["live.example:443"] = time.Now()
+
+	rt.sweepIdle()
+
+	if got := ft.closes(); got != 0 {
+		t.Fatalf("CloseIdleConnections called %d times on a transport in active use, want 0", got)
+	}
+	if _, ok := rt.cachedTransports["live.example:443"]; !ok {
+		t.Fatal("a transport in active use was evicted from the cache")
+	}
+}
+
+// Past idleConnTTL the transport's idle connections are closed, but the cache
+// entry stays so a request still running keeps a transport someone can close.
+func TestSweepIdleClosesIdleConnectionsButKeepsEntry(t *testing.T) {
+	rt := newTestRoundTripper()
+	ft := &fakeIdleTransport{}
+	rt.cachedTransports["idle.example:443"] = ft
+	rt.lastUsed["idle.example:443"] = time.Now().Add(-idleConnTTL - time.Second)
+
+	rt.sweepIdle()
+
+	if got := ft.closes(); got != 1 {
+		t.Fatalf("CloseIdleConnections called %d times past idleConnTTL, want 1", got)
+	}
+	if _, ok := rt.cachedTransports["idle.example:443"]; !ok {
+		t.Fatal("entry evicted at idleConnTTL; eviction is meant to wait for 2*idleConnTTL")
+	}
+}
+
+// Past 2*idleConnTTL nothing can still be using it, so the entry and everything
+// keyed alongside it goes -- otherwise the maps grow once per host contacted.
+func TestSweepIdleEvictsLongIdleTransports(t *testing.T) {
+	rt := newTestRoundTripper()
+	ft := &fakeIdleTransport{}
+	conn := &fakeConn{}
+	addr := "stale.example:443"
+
+	rt.cachedTransports[addr] = ft
+	rt.cachedConnections[addr] = conn
+	rt.lastUsed[addr] = time.Now().Add(-2*idleConnTTL - time.Second)
+	rt.getAddressMutex(addr)
+
+	rt.sweepIdle()
+
+	if _, ok := rt.cachedTransports[addr]; ok {
+		t.Error("transport still cached after 2*idleConnTTL")
+	}
+	if _, ok := rt.cachedConnections[addr]; ok {
+		t.Error("connection still cached after 2*idleConnTTL")
+	}
+	if _, ok := rt.lastUsed[addr]; ok {
+		t.Error("lastUsed entry survived eviction")
+	}
+	if !conn.isClosed() {
+		t.Error("cached connection was dropped without being closed, leaking the socket")
+	}
+
+	rt.addressMutexLock.Lock()
+	_, muExists := rt.addressMutexes[addr]
+	rt.addressMutexLock.Unlock()
+	if muExists {
+		t.Error("address mutex outlived the address it guarded")
+	}
+}
+
+// Sweeping is driven from RoundTrip, so it has to be throttled or every request
+// would walk the whole cache.
+func TestSweepIdleIsThrottled(t *testing.T) {
+	rt := newTestRoundTripper()
+	ft := &fakeIdleTransport{}
+	rt.cachedTransports["idle.example:443"] = ft
+	rt.lastUsed["idle.example:443"] = time.Now().Add(-idleConnTTL - time.Second)
+
+	rt.sweepIdle()
+	rt.sweepIdle()
+	rt.sweepIdle()
+
+	if got := ft.closes(); got != 1 {
+		t.Fatalf("swept %d times in quick succession, want 1 (throttled by idleSweepInterval)", got)
+	}
+}
+
+// The cached connection is a one-shot handoff to the transport's first DialTLS
+// call. Leaving it in place handed every later dial the same conn and pinned
+// every connection the client had ever opened.
+func TestDialTLSConsumesCachedConnection(t *testing.T) {
+	rt := newTestRoundTripper()
+	conn := &fakeConn{}
+	addr := "handoff.example:443"
+	rt.cachedConnections[addr] = conn
+
+	got, err := rt.dialTLS(nil, "tcp", addr)
+	if err != nil {
+		t.Fatalf("dialTLS returned error on cache hit: %v", err)
+	}
+	if got != conn {
+		t.Fatal("dialTLS did not return the cached connection")
+	}
+	if _, ok := rt.cachedConnections[addr]; ok {
+		t.Fatal("cached connection was not consumed; later dials would be handed the same conn")
+	}
+	if conn.isClosed() {
+		t.Fatal("handoff closed the connection it was handing over")
+	}
+}


### PR DESCRIPTION
## Problem

A long-lived `CycleTLS` client accumulates **one permanently open socket per distinct host it has ever contacted**.

`roundTripper` caches a transport per address in `cachedTransports` and never releases one. Nothing bounds the connections underneath either: fhttp's `http2.Transport` only applies an idle timeout when it was built from an `http.Transport` (through the unexported `t1` field), and the transports built in `dialTLS` set `DialTLS` directly — so `idleConnTimeout()` returns 0 and a `ClientConn` is kept for the life of the process.

For a short-lived client this is invisible. For a long-lived one it is unbounded growth. Reproduction — one client, 10 `Do()` calls to 10 different hosts, counting the process's own sockets:

```
after 10 requests to distinct hosts:  9 sockets
after 5 repeats of one host:          9 sockets   (reuse works; no growth)
after the pool has been idle 100s:    9 sockets   (nothing ever closes them)
```

The sockets outlive the requests indefinitely. The only thing that ever closed one in practice was the remote end giving up on it.

This is the same class of bug as #265 ("Each client opens a connection to a server and doesn't close it"), which was fixed for the dispatcher path via `CloseIdleConnections(hostPort)` in `dispatcherAsync`. The Go `Do()` path was added later and never got equivalent treatment.

## Change

**1. Sweep idle transports.** Record when each address was last requested; on a later request, close the idle connections of anything untouched for `idleConnTTL` (90s), and drop the cache entry once untouched for twice that.

`CloseIdleConnections` is what makes this safe — on both `http.Transport` and `http2.Transport` it closes only connections with no request on them, so a sweep can never interrupt traffic in flight. Eviction deliberately waits for the second interval: a request still running holds a transport the map has stopped referring to, and its connections would then have nothing left to close them.

The sweep is driven from `RoundTrip` rather than a background goroutine, since a `roundTripper` has no Close hook one could be stopped from, and it is throttled to once per `idleSweepInterval` (30s) so a busy client is not walking the cache on every request.

**2. Consume the cached connection on handoff.** `cachedConnections[addr]` exists only to hand the just-negotiated conn to the transport's first `DialTLS` call, but it was never removed. That meant every later dial for that address — the ones a transport makes when it wants a *second* connection — was answered with the conn it was already using, and the map held a reference to every connection the client had ever opened.

After the change, same reproduction:

```
after 10 requests to distinct hosts:  8 sockets
after 5 repeats of one host:          8 sockets   (reuse still works)
after the pool has been idle 100s:    8 sockets
after one request drives a sweep:     1 socket
```

## Notes

- No API change, no new dependency; the two constants are package-level so they are easy to make configurable later if you would prefer that.
- Adds 5 regression tests covering the sweep (live addresses untouched, idle ones closed, long-idle ones evicted along with their `addressMutexes` entry, throttling) and the handoff. They use fakes, so no network and no sleeping.
- `go test -race ./cycletls/... ./cycletls/tests/unit/...` passes, including the existing roundtripper concurrency test.